### PR TITLE
LCI subelement encoding and testing

### DIFF
--- a/WifiART/src/structs/AltitudeType.java
+++ b/WifiART/src/structs/AltitudeType.java
@@ -1,0 +1,41 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package structs;
+
+/**
+ * An enum representing the altitude type options for the LCI subelement.
+ */
+public enum AltitudeType {
+    NO_KNOWN_ALTITUDE(0),
+    ALTITUDE_IN_METERS(1),
+    ALTITUDE_IN_FLOORS(2);
+
+    private final int value;
+
+    AltitudeType(int value) {
+        this.value = value;
+    }
+
+    /**
+     * Get the integer encoding representing the altitude type.
+     *
+     * @return the integer encoding
+     */
+    public int getEncoding() {
+        return value;
+    }
+}

--- a/WifiART/src/structs/AltitudeType.java
+++ b/WifiART/src/structs/AltitudeType.java
@@ -20,8 +20,13 @@ package structs;
  * An enum representing the altitude type options for the LCI subelement.
  */
 public enum AltitudeType {
+    /** Altitude not provided. */
     NO_KNOWN_ALTITUDE(0),
+
+    /** Altitude is in meters. */
     ALTITUDE_IN_METERS(1),
+
+    /** Altitude is in floors. */
     ALTITUDE_IN_FLOORS(2);
 
     private final int value;

--- a/WifiART/src/structs/LciState.java
+++ b/WifiART/src/structs/LciState.java
@@ -22,6 +22,12 @@ public class LciState {
     private static final AltitudeType DEFAULT_ALTITUDE_TYPE = AltitudeType.NO_KNOWN_ALTITUDE;
     private static final MapDatum DEFAULT_MAP_DATUM = MapDatum.WGS84;
 
+    private static final double MAX_LATITUDE = 90;
+    private static final double MIN_LATITUDE = -90;
+    private static final double MAX_LONGITUDE = 180;
+    private static final double MIN_LONGITUDE = -180;
+    private static final double MAX_ALTITUDE_MAGNITUDE = Math.pow(2, 21);
+
 
     // Parameters
 
@@ -196,6 +202,9 @@ public class LciState {
      * @param latitude the latitude, in degrees
      */
     public void setLatitude(double latitude) {
+        if (latitude < MIN_LATITUDE || latitude > MAX_LATITUDE) {
+            throw new NumberFormatException();
+        }
         this.latitude = latitude;
     }
 
@@ -214,6 +223,9 @@ public class LciState {
      * @param longitude the longitude, in degrees
      */
     public void setLongitude(double longitude) {
+        if (longitude < MIN_LONGITUDE || longitude > MAX_LONGITUDE) {
+            throw new NumberFormatException();
+        }
         this.longitude = longitude;
     }
 
@@ -232,6 +244,9 @@ public class LciState {
      * @param altitude the altitude, in meters or floors
      */
     public void setAltitude(double altitude) {
+        if (altitude < -MAX_ALTITUDE_MAGNITUDE || altitude >= MAX_ALTITUDE_MAGNITUDE) {
+            throw new NumberFormatException();
+        }
         this.altitude = altitude;
     }
 

--- a/WifiART/src/structs/LciState.java
+++ b/WifiART/src/structs/LciState.java
@@ -28,7 +28,6 @@ public class LciState {
     private static final double MIN_LONGITUDE = -180;
     private static final double MAX_ALTITUDE_MAGNITUDE = Math.pow(2, 21);
 
-
     // Parameters
 
     private int lciVersion;

--- a/WifiART/src/structs/LciState.java
+++ b/WifiART/src/structs/LciState.java
@@ -44,14 +44,14 @@ public class LciState {
     private MapDatum mapDatum; // WGS84, NAD83 (NAVD88), or NAD83 (MLLW).
 
     /**
-     * The regLocAgreement parameter is true if the STA is operating within a national
-     *  policy area or an international agreement area near a national border.
+     * The Registered Location (RegLoc) Agreement parameter is true if the STA is operating within
+     *  a national policy area or an international agreement area near a national border.
      */
     private boolean regLocAgreement;
 
     /**
-     * The regLocDse parameter is true if the enabling STA is enabling the operation
-     *  of STAs with DSE.
+     * The Registered Location Dependent STA Enablement (RegLoc DSE) parameter is true if the
+     *  enabling STA is enabling the operation of STAs with DSE.
      */
     private boolean regLocDse;
 
@@ -155,8 +155,9 @@ public class LciState {
     }
 
     /**
-     * Gets the regLocAgreement parameter, which is true if the STA is operating within a national
-     *  policy area or an international agreement area near a national border.
+     * Gets the Registered Location (RegLoc) Agreement parameter, which is true if the STA is
+     *  operating within a national policy area or an international agreement area near a national
+     *  border.
      *
      * @return the boolean value of the parameter.
      */
@@ -165,8 +166,8 @@ public class LciState {
     }
 
     /**
-     * Gets the regLocDse parameter, which is true if the enabling STA is enabling the operation
-     *  of STAs with DSE.
+     * Gets the Registered Location Dependent STA Enablement (RegLoc DSE) parameter, which is true
+     *  if the enabling STA is enabling the operation of STAs with DSE.
      *
      * @return the boolean value of the parameter.
      */
@@ -278,8 +279,9 @@ public class LciState {
     }
 
     /**
-     * Sets the regLocAgreement parameter, which is true if the STA is operating within a national
-     *  policy area or an international agreement area near a national border.
+     * Sets the Registered Location (RegLoc) Agreement parameter, which is true if the STA is
+     *  operating within a national policy area or an international agreement area near a national
+     *  border.
      *
      * @param regLocAgreement the boolean value of the parameter.
      */
@@ -288,8 +290,8 @@ public class LciState {
     }
 
     /**
-     * Sets the regLocDse parameter, which is true if the enabling STA is enabling the operation
-     *  of STAs with DSE.
+     * Sets the Registered Location Dependent STA Enablement (RegLoc DSE) parameter, which is true
+     *  if the enabling STA is enabling the operation of STAs with DSE.
      *
      * @param regLocDse the boolean value of the parameter.
      */

--- a/WifiART/src/structs/LciState.java
+++ b/WifiART/src/structs/LciState.java
@@ -17,7 +17,16 @@ limitations under the License.
 package structs;
 
 public class LciState {
+    // Constants
+    private static final int DEFAULT_LCI_VERSION = 1;
+    private static final AltitudeType DEFAULT_ALTITUDE_TYPE = AltitudeType.NO_KNOWN_ALTITUDE;
+    private static final MapDatum DEFAULT_MAP_DATUM = MapDatum.WGS84;
+
+
     // Parameters
+
+    private int lciVersion;
+
     private double latitude;
     private double latitudeUncertainty;
     private double longitude;
@@ -25,35 +34,174 @@ public class LciState {
 
     private double altitude;
     private double altitudeUncertainty;
-    private String altitudeUnits; // "Meters" or "Floors"
-    private String altitudeDatum; // "WGS84", "NAD83 (NAVD88)", or "NAD83 (MLLW)".
+    private AltitudeType altitudeType; // Meters, Floors, or no altitude provided
+    private MapDatum mapDatum; // WGS84, NAD83 (NAVD88), or NAD83 (MLLW).
 
-    /* The regLocAgreement parameter is true if the STA is operating within a national
-       policy area or an international agreement area near a national border. */
+    /**
+     * The regLocAgreement parameter is true if the STA is operating within a national
+     *  policy area or an international agreement area near a national border.
+     */
     private boolean regLocAgreement;
-    /* The regLocDse parameter is true if the enabling STA is enabling the operation
-       of STAs with DSE. */
+
+    /**
+     * The regLocDse parameter is true if the enabling STA is enabling the operation
+     *  of STAs with DSE.
+     */
     private boolean regLocDse;
-    /* The dependentSta parameter is true if the STA is operating with the enablement
-       of the enabling STA whose LCI is being reported. */
+
+    /**
+     * The dependentSta parameter is true if the STA is operating with the enablement
+     *  of the enabling STA whose LCI is being reported.
+     */
     private boolean dependentSta;
 
+    /**
+     * Constructs an LciState, assigning default values when needed.
+     */
     public LciState() {
+        lciVersion = DEFAULT_LCI_VERSION;
+        altitudeType = DEFAULT_ALTITUDE_TYPE;
+        mapDatum = DEFAULT_MAP_DATUM;
     }
 
-    // TODO(dmevans) Add getter methods.
+
+    // Getters for the parameters.
+
+    /**
+     * Gets the LCI version.
+     *
+     * @return the LCI version being used
+     */
+    public int getLciVersion() {
+        return lciVersion;
+    }
+
+    /**
+     * Gets the latitude.
+     *
+     * @return the latitude, in degrees
+     */
+    public double getLatitude() {
+        return latitude;
+    }
+
+    /**
+     * Gets the latitude uncertainty.
+     *
+     * @return the latitude uncertainty, in degrees
+     */
+    public double getLatitudeUncertainty() {
+        return latitudeUncertainty;
+    }
+
+    /**
+     * Gets the longitude.
+     *
+     * @return the longitude, in degrees
+     */
+    public double getLongitude() {
+        return longitude;
+    }
+
+    /**
+     * Gets the longitude uncertainty.
+     *
+     * @return the longitude uncertainty, in degrees
+     */
+    public double getLongitudeUncertainty() {
+        return longitudeUncertainty;
+    }
+
+    /**
+     * Gets the altitude.
+     *
+     * @return the altitude, in meters or floors
+     */
+    public double getAltitude() {
+        return altitude;
+    }
+
+    /**
+     * Gets the altitude uncertainty.
+     *
+     * @return the altitude uncertainty, in meters or floors
+     */
+    public double getAltitudeUncertainty() {
+        return altitudeUncertainty;
+    }
+
+    /**
+     * Gets the altitude type (meters, floors, or no known altitude).
+     *
+     * @return the altitude type
+     */
+    public AltitudeType getAltitudeType() {
+        return altitudeType;
+    }
+
+    /**
+     * Gets the map datum.
+     *
+     * @return the map datum
+     */
+    public MapDatum getMapDatum() {
+        return mapDatum;
+    }
+
+    /**
+     * Gets the regLocAgreement parameter, which is true if the STA is operating within a national
+     *  policy area or an international agreement area near a national border.
+     *
+     * @return the boolean value of the parameter.
+     */
+    public boolean getRegLocAgreement() {
+        return regLocAgreement;
+    }
+
+    /**
+     * Gets the regLocDse parameter, which is true if the enabling STA is enabling the operation
+     *  of STAs with DSE.
+     *
+     * @return the boolean value of the parameter.
+     */
+    public boolean getRegLocDse() {
+        return regLocDse;
+    }
+
+    /**
+     * Gets the dependentSta parameter, which is true if the STA is operating with the enablement
+     *  of the enabling STA whose LCI is being reported.
+     *
+     * @return the boolean value of the parameter.
+     */
+    public boolean getDependentSta() {
+        return dependentSta;
+    }
+
+
+    // Setters for the parameters
+
+    /**
+     * Sets the LCI version.
+     *
+     * @param lciVersion the LCI version
+     */
+    public void setLciVersion(int lciVersion) {
+        this.lciVersion = lciVersion;
+    }
 
     /**
      * Sets the latitude.
+     *
      * @param latitude the latitude, in degrees
      */
     public void setLatitude(double latitude) {
         this.latitude = latitude;
     }
 
-
     /**
-     * Sets the latitude uncertainty
+     * Sets the latitude uncertainty.
+     *
      * @param latitudeUncertainty the latitude uncertainty, in degrees
      */
     public void setLatitudeUncertainty(double latitudeUncertainty) {
@@ -61,7 +209,8 @@ public class LciState {
     }
 
     /**
-     * Sets the longitude
+     * Sets the longitude.
+     *
      * @param longitude the longitude, in degrees
      */
     public void setLongitude(double longitude) {
@@ -69,7 +218,8 @@ public class LciState {
     }
 
     /**
-     * Sets the longitude uncertainty
+     * Sets the longitude uncertainty.
+     *
      * @param longitudeUncertainty the longitude uncertainty, in degrees
      */
     public void setLongitudeUncertainty(double longitudeUncertainty) {
@@ -78,6 +228,7 @@ public class LciState {
 
     /**
      * Sets the altitude.
+     *
      * @param altitude the altitude, in meters or floors
      */
     public void setAltitude(double altitude) {
@@ -86,6 +237,7 @@ public class LciState {
 
     /**
      * Sets the altitude uncertainty.
+     *
      * @param altitudeUncertainty the altitude uncertainty, in meters or floors
      */
     public void setAltitudeUncertainty(double altitudeUncertainty) {
@@ -93,24 +245,27 @@ public class LciState {
     }
 
     /**
-     * Sets the altitude units (meters or floors).
-     * @param altitudeUnits the altitude units ("Meters" or "Floors")
+     * Sets the altitude type (meters, floors, or no known altitude).
+     *
+     * @param altitudeType the altitude type (meters, floors, or no known altitude)
      */
-    public void setAltitudeUnits(String altitudeUnits) {
-        this.altitudeUnits = altitudeUnits;
+    public void setAltitudeType(AltitudeType altitudeType) {
+        this.altitudeType = altitudeType;
     }
 
     /**
-     * Sets the altitude datum.
-     * @param altitudeDatum the map datum ("WGS84", "NAD83 (NAVD88)", or "NAD83 (MLLW)")
+     * Sets the map datum.
+     *
+     * @param mapDatum the map datum
      */
-    public void setAltitudeDatum(String altitudeDatum) {
-        this.altitudeDatum = altitudeDatum;
+    public void setMapDatum(MapDatum mapDatum) {
+        this.mapDatum = mapDatum;
     }
 
     /**
      * Sets the regLocAgreement parameter, which is true if the STA is operating within a national
      *  policy area or an international agreement area near a national border.
+     *
      * @param regLocAgreement the boolean value of the parameter.
      */
     public void setRegLocAgreement(boolean regLocAgreement) {
@@ -120,6 +275,7 @@ public class LciState {
     /**
      * Sets the regLocDse parameter, which is true if the enabling STA is enabling the operation
      *  of STAs with DSE.
+     *
      * @param regLocDse the boolean value of the parameter.
      */
     public void setRegLocDse(boolean regLocDse) {
@@ -129,9 +285,12 @@ public class LciState {
     /**
      * Sets the dependentSta parameter, which is true if the STA is operating with the enablement
      *  of the enabling STA whose LCI is being reported.
-     * @param dependentSta
+     *
+     * @param dependentSta the boolean value of the parameter.
      */
     public void setDependentSta(boolean dependentSta) {
         this.dependentSta = dependentSta;
     }
+
+
 }

--- a/WifiART/src/structs/MapDatum.java
+++ b/WifiART/src/structs/MapDatum.java
@@ -1,0 +1,42 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package structs;
+
+/**
+ * An enum representing the map datum options for the LCI subelement.
+ */
+public enum MapDatum {
+    WGS84(1),
+    NAD83_NAVD88(2),
+    NAD83_MLLW(3);
+
+    private final int value;
+
+    MapDatum(int value) {
+        this.value = value;
+    }
+
+    /**
+     * Get the integer encoding representing the map datum.
+     *
+     * @return the integer encoding
+     */
+    public int getEncoding() {
+        return value;
+    }
+
+}

--- a/WifiART/src/structs/MapDatum.java
+++ b/WifiART/src/structs/MapDatum.java
@@ -20,8 +20,20 @@ package structs;
  * An enum representing the map datum options for the LCI subelement.
  */
 public enum MapDatum {
+
+    /** WGS84 datum: World Geodetic System of 1984. */
     WGS84(1),
+
+    /**
+     * NAD83 (NAVD88) datum: horizontal datum is the North American Datum of 1983 (NAD83),
+     *  vertical datum is the North American Vertical datum of 1988 (NAVD88).
+     */
     NAD83_NAVD88(2),
+
+    /**
+     * NAD83 (MLLW) datum: horizontal datum is the North American Datum of 1983 (NAD83),
+     *  vertical datum is the Mean Lower Low Water (MLLW) datum.
+     */
     NAD83_MLLW(3);
 
     private final int value;

--- a/WifiART/src/test/userinterface/LciTest.java
+++ b/WifiART/src/test/userinterface/LciTest.java
@@ -1,0 +1,141 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package userinterface;
+
+import org.junit.jupiter.api.Test;
+import structs.AltitudeType;
+import structs.LciState;
+import structs.MapDatum;
+import structs.UsageState;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests methods and the encoding for the Usage Rules/Policy subelement.
+ */
+class LciTest {
+
+    // Extreme values
+    private static final double MAX_LATITUDE = 90;
+    private static final double MIN_LATITUDE = -90;
+    private static final double MAX_LATITUDE_UNCERTAINTY = Math.pow(2.0, 7.0);
+    private static final double MIN_LATITUDE_UNCERTAINTY = Math.pow(2.0, -26.0);
+    private static final double MAX_LONGITUDE = 180;
+    private static final double MIN_LONGITUDE = -180;
+    private static final double MAX_LONGITUDE_UNCERTAINTY = Math.pow(2.0, 7.0);
+    private static final double MIN_LONGITUDE_UNCERTAINTY = Math.pow(2.0, -26.0);
+    private static final double MAX_ALTITUDE = 0x1fffffff / 256.0;
+    private static final double MIN_ALTITUDE = 0xe0000000 / 256.0;
+    private static final double MAX_ALTITUDE_UNCERTAINTY = Math.pow(2.0, 20.0);
+    private static final double MIN_ALTITUDE_UNCERTAINTY = Math.pow(2.0, -9.0);
+
+
+
+    // States and expected buffers for testing
+
+    // Default state with false/zero values.
+    private static final LciState STATE_DEFAULT = buildLciState(
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        AltitudeType.NO_KNOWN_ALTITUDE,
+        MapDatum.WGS84,
+        false,
+        false,
+        false,
+        1);
+    private static final String BUFFER_DEFAULT = "001000000000000000000000000000000041";
+
+    private static final LciState STATE_WITH_MAX_LAT_LONG_ALT = buildLciState(
+        MAX_LATITUDE,
+        MAX_LATITUDE_UNCERTAINTY,
+        MAX_LONGITUDE,
+        MAX_LONGITUDE_UNCERTAINTY,
+        MAX_ALTITUDE,
+        MAX_ALTITUDE_UNCERTAINTY,
+        STATE_DEFAULT.getAltitudeType(),
+        STATE_DEFAULT.getMapDatum(),
+        STATE_DEFAULT.getRegLocAgreement(),
+        STATE_DEFAULT.getRegLocDse(),
+        STATE_DEFAULT.getDependentSta(),
+        STATE_DEFAULT.getLciVersion()
+    );
+
+
+    private final LciModel model = new LciModel(new LciState());
+
+    /**
+     * Constructs an LciState with pre-determined parameter values.
+     *
+     * @param latitude the latitude, in degrees
+     * @param latitudeUncertainty the latitude uncertainty, in degrees
+     * @param longitude the longitude, in degrees
+     * @param longitudeUncertainty the longitude uncertainty, in degrees
+     * @param altitude the altitude
+     * @param altitudeUncertainty the altitude uncertainty
+     * @param altitudeType the altitude type (meters, floors, or no known altitude)
+     * @param mapDatum the map datum
+     * @param regLocAgreement true if the STA is operating within a national policy area or an
+     *                        international agreement area near a national border.
+     * @param regLocDse true if the enabling STA is enabling the operation of STAs with DSE.
+     * @param dependentSta true if the STA is operating with the enablement of the enabling STA
+     *                     whose LCI is being reported.
+     * @param lciVersion the LCI version
+     * @return the LciState with the parameter values set.
+     */
+    private static LciState buildLciState(double latitude, double latitudeUncertainty,
+                                            double longitude, double longitudeUncertainty,
+                                            double altitude, double altitudeUncertainty,
+                                            AltitudeType altitudeType, MapDatum mapDatum,
+                                            boolean regLocAgreement, boolean regLocDse,
+                                            boolean dependentSta, int lciVersion){
+        LciState state = new LciState();
+        state.setLatitude(latitude);
+        state.setLatitudeUncertainty(latitudeUncertainty);
+        state.setLongitude(longitude);
+        state.setLongitudeUncertainty(longitudeUncertainty);
+        state.setAltitude(altitude);
+        state.setAltitudeUncertainty(altitudeUncertainty);
+        state.setAltitudeType(altitudeType);
+        state.setMapDatum(mapDatum);
+        state.setRegLocAgreement(regLocAgreement);
+        state.setRegLocDse(regLocDse);
+        state.setDependentSta(dependentSta);
+        state.setLciVersion(lciVersion);
+        return state;
+    }
+
+    /**
+     * Test the encoding with default values (false, zero).
+     */
+    @Test
+    void testDefaultBuffer() {
+        model.setState(STATE_DEFAULT);
+
+        String buffer = model.toHexBuffer();
+
+        assertEquals(BUFFER_DEFAULT, buffer);
+    }
+
+}
+

--- a/WifiART/src/test/userinterface/LciTest.java
+++ b/WifiART/src/test/userinterface/LciTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 import structs.AltitudeType;
 import structs.LciState;
 import structs.MapDatum;
-import structs.UsageState;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -33,12 +32,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class LciTest {
 
     // Extreme values
-    private static final double MAX_LATITUDE = 90;
-    private static final double MIN_LATITUDE = -90;
+    private static final double MAX_LATITUDE = 90.0;
+    private static final double MIN_LATITUDE = -90.0;
     private static final double MAX_LATITUDE_UNCERTAINTY = Math.pow(2.0, 7.0);
     private static final double MIN_LATITUDE_UNCERTAINTY = Math.pow(2.0, -26.0);
-    private static final double MAX_LONGITUDE = 180;
-    private static final double MIN_LONGITUDE = -180;
+    private static final double MAX_LONGITUDE = 180.0;
+    private static final double MIN_LONGITUDE = -180.0;
     private static final double MAX_LONGITUDE_UNCERTAINTY = Math.pow(2.0, 7.0);
     private static final double MIN_LONGITUDE_UNCERTAINTY = Math.pow(2.0, -26.0);
     private static final double MAX_ALTITUDE = 0x1fffffff / 256.0;
@@ -66,6 +65,24 @@ class LciTest {
         1);
     private static final String BUFFER_DEFAULT = "001000000000000000000000000000000041";
 
+    // State representing the Sydney Opera House.
+    private static final LciState STATE_SYDNEY_OPERA_HOUSE_EXAMPLE = buildLciState(
+        -33.8570095,
+        0.0007105,
+        151.2152005,
+        0.0007055,
+        11.2,
+        33.7,
+        AltitudeType.ALTITUDE_IN_METERS,
+        MapDatum.WGS84,
+        false,
+        false,
+        false,
+        1
+    );
+    private static final String BUFFER_SYDNEY_OPERA_HOUSE_EXAMPLE = "001052834d12efd2b08b9b4bf1cc2c000041";
+
+    // Maximum values
     private static final LciState STATE_WITH_MAX_LAT_LONG_ALT = buildLciState(
         MAX_LATITUDE,
         MAX_LATITUDE_UNCERTAINTY,
@@ -80,6 +97,143 @@ class LciTest {
         STATE_DEFAULT.getDependentSta(),
         STATE_DEFAULT.getLciVersion()
     );
+    private static final String BUFFER_WITH_MAX_LAT_LONG_ALT = "0010010000002d010000005a10fcffff7f41";
+
+    // Minimum values
+    private static final LciState STATE_WITH_MIN_LAT_LONG_ALT = buildLciState(
+        MIN_LATITUDE,
+        MIN_LATITUDE_UNCERTAINTY,
+        MIN_LONGITUDE,
+        MIN_LONGITUDE_UNCERTAINTY,
+        MIN_ALTITUDE,
+        MIN_ALTITUDE_UNCERTAINTY,
+        STATE_DEFAULT.getAltitudeType(),
+        STATE_DEFAULT.getMapDatum(),
+        STATE_DEFAULT.getRegLocAgreement(),
+        STATE_DEFAULT.getRegLocDse(),
+        STATE_DEFAULT.getDependentSta(),
+        STATE_DEFAULT.getLciVersion()
+    );
+    private static final String BUFFER_WITH_MIN_LAT_LONG_ALT = "001022000000d322000000a6e00100008041";
+
+    // Altitude Type is set to Altitude In Floors.
+    private static final LciState STATE_WITH_ALTITUDE_IN_FLOORS = buildLciState(
+        STATE_DEFAULT.getLatitude(),
+        STATE_DEFAULT.getLatitudeUncertainty(),
+        STATE_DEFAULT.getLongitude(),
+        STATE_DEFAULT.getLongitudeUncertainty(),
+        STATE_DEFAULT.getAltitude(),
+        STATE_DEFAULT.getAltitudeUncertainty(),
+        AltitudeType.ALTITUDE_IN_FLOORS,
+        STATE_DEFAULT.getMapDatum(),
+        STATE_DEFAULT.getRegLocAgreement(),
+        STATE_DEFAULT.getRegLocDse(),
+        STATE_DEFAULT.getDependentSta(),
+        STATE_DEFAULT.getLciVersion()
+    );
+    private static final String BUFFER_WITH_ALTITUDE_IN_FLOORS = "001000000000000000000000020000000041";
+
+    // Altitude Type is set to Altitude In Meters.
+    private static final LciState STATE_WITH_ALTITUDE_IN_METERS = buildLciState(
+        STATE_DEFAULT.getLatitude(),
+        STATE_DEFAULT.getLatitudeUncertainty(),
+        STATE_DEFAULT.getLongitude(),
+        STATE_DEFAULT.getLongitudeUncertainty(),
+        STATE_DEFAULT.getAltitude(),
+        STATE_DEFAULT.getAltitudeUncertainty(),
+        AltitudeType.ALTITUDE_IN_METERS,
+        STATE_DEFAULT.getMapDatum(),
+        STATE_DEFAULT.getRegLocAgreement(),
+        STATE_DEFAULT.getRegLocDse(),
+        STATE_DEFAULT.getDependentSta(),
+        STATE_DEFAULT.getLciVersion()
+    );
+    private static final String BUFFER_WITH_ALTITUDE_IN_METERS = "001000000000000000000000010000000041";
+
+    // Map Datum is set to NAD83 (NAVD88).
+    private static final LciState STATE_WITH_NAD83_NAVD88 = buildLciState(
+        STATE_DEFAULT.getLatitude(),
+        STATE_DEFAULT.getLatitudeUncertainty(),
+        STATE_DEFAULT.getLongitude(),
+        STATE_DEFAULT.getLongitudeUncertainty(),
+        STATE_DEFAULT.getAltitude(),
+        STATE_DEFAULT.getAltitudeUncertainty(),
+        STATE_DEFAULT.getAltitudeType(),
+        MapDatum.NAD83_NAVD88,
+        STATE_DEFAULT.getRegLocAgreement(),
+        STATE_DEFAULT.getRegLocDse(),
+        STATE_DEFAULT.getDependentSta(),
+        STATE_DEFAULT.getLciVersion()
+    );
+    private static final String BUFFER_WITH_NAD83_NAVD88 = "001000000000000000000000000000000042";
+
+    // Map Datum is set to NAD83 (MLLW).
+    private static final LciState STATE_WITH_NAD83_MLLW = buildLciState(
+        STATE_DEFAULT.getLatitude(),
+        STATE_DEFAULT.getLatitudeUncertainty(),
+        STATE_DEFAULT.getLongitude(),
+        STATE_DEFAULT.getLongitudeUncertainty(),
+        STATE_DEFAULT.getAltitude(),
+        STATE_DEFAULT.getAltitudeUncertainty(),
+        STATE_DEFAULT.getAltitudeType(),
+        MapDatum.NAD83_MLLW,
+        STATE_DEFAULT.getRegLocAgreement(),
+        STATE_DEFAULT.getRegLocDse(),
+        STATE_DEFAULT.getDependentSta(),
+        STATE_DEFAULT.getLciVersion()
+    );
+    private static final String BUFFER_WITH_NAD83_MLLW = "001000000000000000000000000000000043";
+
+    // RegLoc Agreement parameter is true.
+    private static final LciState STATE_WITH_REG_LOC_AGREEMENT_TRUE = buildLciState(
+        STATE_DEFAULT.getLatitude(),
+        STATE_DEFAULT.getLatitudeUncertainty(),
+        STATE_DEFAULT.getLongitude(),
+        STATE_DEFAULT.getLongitudeUncertainty(),
+        STATE_DEFAULT.getAltitude(),
+        STATE_DEFAULT.getAltitudeUncertainty(),
+        STATE_DEFAULT.getAltitudeType(),
+        STATE_DEFAULT.getMapDatum(),
+        true,
+        STATE_DEFAULT.getRegLocDse(),
+        STATE_DEFAULT.getDependentSta(),
+        STATE_DEFAULT.getLciVersion()
+    );
+    private static final String BUFFER_WITH_REG_LOC_AGREEMENT_TRUE = "001000000000000000000000000000000049";
+
+    // RegLoc DSE parameter is true.
+    private static final LciState STATE_WITH_REG_LOC_DSE_TRUE = buildLciState(
+        STATE_DEFAULT.getLatitude(),
+        STATE_DEFAULT.getLatitudeUncertainty(),
+        STATE_DEFAULT.getLongitude(),
+        STATE_DEFAULT.getLongitudeUncertainty(),
+        STATE_DEFAULT.getAltitude(),
+        STATE_DEFAULT.getAltitudeUncertainty(),
+        STATE_DEFAULT.getAltitudeType(),
+        STATE_DEFAULT.getMapDatum(),
+        STATE_DEFAULT.getRegLocAgreement(),
+        true,
+        STATE_DEFAULT.getDependentSta(),
+        STATE_DEFAULT.getLciVersion()
+    );
+    private static final String BUFFER_WITH_REG_LOC_DSE_TRUE = "001000000000000000000000000000000051";
+
+    // Dependent STA parameter is true.
+    private static final LciState STATE_WITH_DEPENDENT_STA_TRUE = buildLciState(
+        STATE_DEFAULT.getLatitude(),
+        STATE_DEFAULT.getLatitudeUncertainty(),
+        STATE_DEFAULT.getLongitude(),
+        STATE_DEFAULT.getLongitudeUncertainty(),
+        STATE_DEFAULT.getAltitude(),
+        STATE_DEFAULT.getAltitudeUncertainty(),
+        STATE_DEFAULT.getAltitudeType(),
+        STATE_DEFAULT.getMapDatum(),
+        STATE_DEFAULT.getRegLocAgreement(),
+        STATE_DEFAULT.getRegLocDse(),
+        true,
+        STATE_DEFAULT.getLciVersion()
+    );
+    private static final String BUFFER_WITH_DEPENDENT_STA_TRUE = "001000000000000000000000000000000061";
 
 
     private final LciModel model = new LciModel(new LciState());
@@ -126,6 +280,373 @@ class LciTest {
     }
 
     /**
+     * Test setting the latitude to the minimum value.
+     */
+    @Test
+    void testSetMinLatitude() {
+        LciState state = new LciState();
+
+        state.setLatitude(MIN_LATITUDE);
+
+        assertEquals(MIN_LATITUDE, state.getLatitude());
+    }
+
+    /**
+     * Test setting the latitude to the maximum value.
+     */
+    @Test
+    void testSetMaxLatitude() {
+        LciState state = new LciState();
+
+        state.setLatitude(MAX_LATITUDE);
+
+        assertEquals(MAX_LATITUDE, state.getLatitude());
+    }
+
+    /**
+     * Test setting the latitude to below the minimum value.
+     */
+    @Test
+    void testSetTooSmallLatitude() {
+        LciState state = new LciState();
+
+        assertThrows(NumberFormatException.class,
+            () -> state.setLatitude(MIN_LATITUDE - 1));
+    }
+
+    /**
+     * Test setting the latitude to above the maximum value.
+     */
+    @Test
+    void testSetTooLargeLatitude() {
+        LciState state = new LciState();
+
+        assertThrows(NumberFormatException.class,
+            () -> state.setLatitude(MAX_LATITUDE + 1));
+    }
+
+    /**
+     * Test setting the latitude uncertainty to the minimum value.
+     */
+    @Test
+    void testSetMinLatitudeUncertainty() {
+        LciState state = new LciState();
+
+        state.setLatitudeUncertainty(MIN_LATITUDE_UNCERTAINTY);
+
+        assertEquals(MIN_LATITUDE_UNCERTAINTY, state.getLatitudeUncertainty());
+    }
+
+    /**
+     * Test setting the latitude uncertainty to the maximum value.
+     */
+    @Test
+    void testSetMaxLatitudeUncertainty() {
+        LciState state = new LciState();
+
+        state.setLatitudeUncertainty(MAX_LATITUDE_UNCERTAINTY);
+
+        assertEquals(MAX_LATITUDE_UNCERTAINTY, state.getLatitudeUncertainty());
+    }
+
+    /**
+     * Test setting the longitude to the minimum value.
+     */
+    @Test
+    void testSetMinLongitude() {
+        LciState state = new LciState();
+
+        state.setLongitude(MIN_LONGITUDE);
+
+        assertEquals(MIN_LONGITUDE, state.getLongitude());
+    }
+
+    /**
+     * Test setting the longitude to the maximum value.
+     */
+    @Test
+    void testSetMaxLongitude() {
+        LciState state = new LciState();
+
+        state.setLongitude(MAX_LONGITUDE);
+
+        assertEquals(MAX_LONGITUDE, state.getLongitude());
+    }
+
+    /**
+     * Test setting the longitude to below the minimum value.
+     */
+    @Test
+    void testSetTooSmallLongitude() {
+        LciState state = new LciState();
+
+        assertThrows(NumberFormatException.class,
+            () -> state.setLongitude(MIN_LONGITUDE - 1));
+    }
+
+    /**
+     * Test setting the longitude to above the maximum value.
+     */
+    @Test
+    void testSetTooLargeLongitude() {
+        LciState state = new LciState();
+
+        assertThrows(NumberFormatException.class,
+            () -> state.setLongitude(MAX_LONGITUDE + 1));
+    }
+
+    /**
+     * Test setting the longitude uncertainty to the minimum value.
+     */
+    @Test
+    void testSetMinLongitudeUncertainty() {
+        LciState state = new LciState();
+
+        state.setLongitudeUncertainty(MIN_LONGITUDE_UNCERTAINTY);
+
+        assertEquals(MIN_LONGITUDE_UNCERTAINTY, state.getLongitudeUncertainty());
+    }
+
+    /**
+     * Test setting the longitude uncertainty to the maximum value.
+     */
+    @Test
+    void testSetMaxLongitudeUncertainty() {
+        LciState state = new LciState();
+
+        state.setLongitudeUncertainty(MAX_LONGITUDE_UNCERTAINTY);
+
+        assertEquals(MAX_LONGITUDE_UNCERTAINTY, state.getLongitudeUncertainty());
+    }
+
+    /**
+     * Test setting the altitude to the minimum value.
+     */
+    @Test
+    void testSetMinAltitude() {
+        LciState state = new LciState();
+
+        state.setAltitude(MIN_ALTITUDE);
+
+        assertEquals(MIN_ALTITUDE, state.getAltitude());
+    }
+
+    /**
+     * Test setting the altitude to the maximum value.
+     */
+    @Test
+    void testSetMaxAltitude() {
+        LciState state = new LciState();
+
+        state.setAltitude(MAX_ALTITUDE);
+
+        assertEquals(MAX_ALTITUDE, state.getAltitude());
+    }
+
+    /**
+     * Test setting the altitude to below the minimum value.
+     */
+    @Test
+    void testSetTooSmallAltitude() {
+        LciState state = new LciState();
+
+        assertThrows(NumberFormatException.class,
+            () -> state.setAltitude(MIN_ALTITUDE - 1));
+    }
+
+    /**
+     * Test setting the altitude to above the maximum value.
+     */
+    @Test
+    void testSetTooLargeAltitude() {
+        LciState state = new LciState();
+
+        assertThrows(NumberFormatException.class,
+            () -> state.setAltitude(MAX_ALTITUDE + 1));
+    }
+
+    /**
+     * Test setting the altitude uncertainty to the minimum value.
+     */
+    @Test
+    void testSetMinAltitudeUncertainty() {
+        LciState state = new LciState();
+
+        state.setAltitudeUncertainty(MIN_ALTITUDE_UNCERTAINTY);
+
+        assertEquals(MIN_ALTITUDE_UNCERTAINTY, state.getAltitudeUncertainty());
+    }
+
+    /**
+     * Test setting the altitude uncertainty to the maximum value.
+     */
+    @Test
+    void testSetMaxAltitudeUncertainty() {
+        LciState state = new LciState();
+
+        state.setAltitudeUncertainty(MAX_ALTITUDE_UNCERTAINTY);
+
+        assertEquals(MAX_ALTITUDE_UNCERTAINTY, state.getAltitudeUncertainty());
+    }
+
+    /**
+     * Test setting the Altitude Type to meters.
+     */
+    @Test
+    void testSetAltitudeInMeters() {
+        LciState state = new LciState();
+
+        state.setAltitudeType(AltitudeType.ALTITUDE_IN_METERS);
+
+        assertEquals(AltitudeType.ALTITUDE_IN_METERS, state.getAltitudeType());
+    }
+
+    /**
+     * Test setting the Altitude Type to floors.
+     */
+    @Test
+    void testSetAltitudeInFloors() {
+        LciState state = new LciState();
+
+        state.setAltitudeType(AltitudeType.ALTITUDE_IN_FLOORS);
+
+        assertEquals(AltitudeType.ALTITUDE_IN_FLOORS, state.getAltitudeType());
+    }
+
+    /**
+     * Test setting the Altitude Type to unknown.
+     */
+    @Test
+    void testSetAltitudeUnknown() {
+        LciState state = new LciState();
+
+        state.setAltitudeType(AltitudeType.NO_KNOWN_ALTITUDE);
+
+        assertEquals(AltitudeType.NO_KNOWN_ALTITUDE, state.getAltitudeType());
+    }
+
+    /**
+     * Test setting the Map Datum to WGS84.
+     */
+    @Test
+    void testSetDatumWgs84() {
+        LciState state = new LciState();
+
+        state.setMapDatum(MapDatum.WGS84);
+
+        assertEquals(MapDatum.WGS84, state.getMapDatum());
+    }
+
+    /**
+     * Test setting the Map Datum to NAD83 (NAVD88).
+     */
+    @Test
+    void testSetDatumNad83Navd88() {
+        LciState state = new LciState();
+
+        state.setMapDatum(MapDatum.NAD83_NAVD88);
+
+        assertEquals(MapDatum.NAD83_NAVD88, state.getMapDatum());
+    }
+
+    /**
+     * Test setting the Map Datum to NAD83 (MLLW).
+     */
+    @Test
+    void testSetDatumNad83Mllw() {
+        LciState state = new LciState();
+
+        state.setMapDatum(MapDatum.NAD83_MLLW);
+
+        assertEquals(MapDatum.NAD83_MLLW, state.getMapDatum());
+    }
+
+    /**
+     * Test setting the RegLoc Agreement parameter to true.
+     */
+    @Test
+    void testSetRegLocAgreementTrue() {
+        LciState state = new LciState();
+
+        state.setRegLocAgreement(true);
+
+        assertTrue(state.getRegLocAgreement());
+    }
+
+    /**
+     * Test setting the RegLoc Agreement parameter to false.
+     */
+    @Test
+    void testSetRegLocAgreementFalse() {
+        LciState state = new LciState();
+
+        state.setRegLocAgreement(false);
+
+        assertFalse(state.getRegLocAgreement());
+    }
+
+    /**
+     * Test setting the RegLoc DSE parameter to true.
+     */
+    @Test
+    void testSetRegLocDseTrue() {
+        LciState state = new LciState();
+
+        state.setRegLocDse(true);
+
+        assertTrue(state.getRegLocDse());
+    }
+
+    /**
+     * Test setting the RegLoc DSE parameter to false.
+     */
+    @Test
+    void testSetRegLocDseFalse() {
+        LciState state = new LciState();
+
+        state.setRegLocDse(false);
+
+        assertFalse(state.getRegLocDse());
+    }
+
+    /**
+     * Test setting the Dependent STA parameter to true.
+     */
+    @Test
+    void testSetDependentStaTrue() {
+        LciState state = new LciState();
+
+        state.setDependentSta(true);
+
+        assertTrue(state.getDependentSta());
+    }
+
+    /**
+     * Test setting the Dependent STA parameter to false.
+     */
+    @Test
+    void testSetDependentStaFalse() {
+        LciState state = new LciState();
+
+        state.setDependentSta(false);
+
+        assertFalse(state.getDependentSta());
+    }
+
+    /**
+     * Test setting the LCI version.
+     */
+    @Test
+    void testSetLciVersion() {
+        LciState state = new LciState();
+
+        state.setLciVersion(1);
+
+        assertEquals(1, state.getLciVersion());
+    }
+
+
+    /**
      * Test the encoding with default values (false, zero).
      */
     @Test
@@ -137,5 +658,124 @@ class LciTest {
         assertEquals(BUFFER_DEFAULT, buffer);
     }
 
-}
+    /**
+     * Test the encoding with the Sydney Opera House example.
+     */
+    @Test
+    void testBufferSydneyOperaHouseExample() {
+        model.setState(STATE_SYDNEY_OPERA_HOUSE_EXAMPLE);
 
+        String buffer = model.toHexBuffer();
+
+        assertEquals(BUFFER_SYDNEY_OPERA_HOUSE_EXAMPLE, buffer);
+    }
+
+    /**
+     * Test the encoding with maximum values.
+     */
+    @Test
+    void testBufferWithMaxLatLongAlt() {
+        model.setState(STATE_WITH_MAX_LAT_LONG_ALT);
+
+        String buffer = model.toHexBuffer();
+
+        assertEquals(BUFFER_WITH_MAX_LAT_LONG_ALT, buffer);
+    }
+
+    /**
+     * Test the encoding with minimum values.
+     */
+    @Test
+    void testBufferWithMinLatLongAlt() {
+        model.setState(STATE_WITH_MIN_LAT_LONG_ALT);
+
+        String buffer = model.toHexBuffer();
+
+        assertEquals(BUFFER_WITH_MIN_LAT_LONG_ALT, buffer);
+    }
+
+    /**
+     * Test the encoding with altitude in floors.
+     */
+    @Test
+    void testBufferWithAltitudeInFloors() {
+        model.setState(STATE_WITH_ALTITUDE_IN_FLOORS);
+
+        String buffer = model.toHexBuffer();
+
+        assertEquals(BUFFER_WITH_ALTITUDE_IN_FLOORS, buffer);
+    }
+
+    /**
+     * Test the encoding with altitude in meters.
+     */
+    @Test
+    void testBufferWithAltitudeInMeters() {
+        model.setState(STATE_WITH_ALTITUDE_IN_METERS);
+
+        String buffer = model.toHexBuffer();
+
+        assertEquals(BUFFER_WITH_ALTITUDE_IN_METERS, buffer);
+    }
+
+    /**
+     * Test the encoding with NAD83 (NAVD88) datum.
+     */
+    @Test
+    void testBufferWithNad83Navd88() {
+        model.setState(STATE_WITH_NAD83_NAVD88);
+
+        String buffer = model.toHexBuffer();
+
+        assertEquals(BUFFER_WITH_NAD83_NAVD88, buffer);
+    }
+
+    /**
+     * Test the encoding with NAD83 (MLLW) datum.
+     */
+    @Test
+    void testBufferWithNad83Mllw() {
+        model.setState(STATE_WITH_NAD83_MLLW);
+
+        String buffer = model.toHexBuffer();
+
+        assertEquals(BUFFER_WITH_NAD83_MLLW, buffer);
+    }
+
+    /**
+     * Test the encoding with the RegLoc Agreement paramter set to true.
+     */
+    @Test
+    void testBufferWithRegLocAgreementTrue() {
+        model.setState(STATE_WITH_REG_LOC_AGREEMENT_TRUE);
+
+        String buffer = model.toHexBuffer();
+
+        assertEquals(BUFFER_WITH_REG_LOC_AGREEMENT_TRUE, buffer);
+    }
+
+    /**
+     * Test the encoding with the RegLoc DSE paramter set to true.
+     */
+    @Test
+    void testBufferWithRegLocDseTrue() {
+        model.setState(STATE_WITH_REG_LOC_DSE_TRUE);
+
+        String buffer = model.toHexBuffer();
+
+        assertEquals(BUFFER_WITH_REG_LOC_DSE_TRUE, buffer);
+    }
+
+    /**
+     * Test the encoding with the Dependent STA paramter set to true.
+     */
+    @Test
+    void testBufferWithDependentStaTrue() {
+        model.setState(STATE_WITH_DEPENDENT_STA_TRUE);
+
+        String buffer = model.toHexBuffer();
+
+        assertEquals(BUFFER_WITH_DEPENDENT_STA_TRUE, buffer);
+    }
+
+}

--- a/WifiART/src/test/userinterface/LciTest.java
+++ b/WifiART/src/test/userinterface/LciTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Tests methods and the encoding for the Usage Rules/Policy subelement.
+ * Tests methods and the encoding for the LCI subelement.
  */
 class LciTest {
 

--- a/WifiART/src/userinterface/LciController.java
+++ b/WifiART/src/userinterface/LciController.java
@@ -30,6 +30,29 @@ public class LciController {
         this.view = view;
         this.model.setCallback(this);
 
-        // TODO(dmevans) Add listeners here.
+        view.addLatitudeListener(actionEvent ->
+            model.getState().setLatitude(view.getLatitude()));
+        view.addLatitudeUncertaintyListener(actionEvent ->
+            model.getState().setLatitudeUncertainty(view.getLatitudeUncertainty()));
+        view.addLongitudeListener(actionEvent ->
+            model.getState().setLongitude(view.getLongitude()));
+        view.addLongitudeUncertaintyListener(actionEvent ->
+            model.getState().setLongitudeUncertainty(view.getLongitudeUncertainty()));
+        view.addAltitudeListener(actionEvent ->
+            model.getState().setAltitude(view.getAltitude()));
+        view.addAltitudeUncertaintyListener(actionEvent ->
+            model.getState().setAltitudeUncertainty(view.getAltitudeUncertainty()));
+        view.addAltitudeTypeListener(actionEvent ->
+            model.getState().setAltitudeType(view.getAltitudeType()));
+        view.addMapDatumListener(actionEvent ->
+            model.getState().setMapDatum(view.getMapDatum()));
+        view.addRegLocAgreementListener(actionEvent ->
+            model.getState().setRegLocAgreement(view.getRegLocAgreement()));
+        view.addRegLocDseListener(actionEvent ->
+            model.getState().setRegLocDse(view.getRegLocDse()));
+        view.addDependentStaListener(actionEvent ->
+            model.getState().setDependentSta(view.getDependentSta()));
+        view.addLciVersionListener(actionEvent ->
+            model.getState().setLciVersion(view.getLciVersion()));
     }
 }

--- a/WifiART/src/userinterface/LciController.java
+++ b/WifiART/src/userinterface/LciController.java
@@ -17,6 +17,17 @@ limitations under the License.
 package userinterface;
 
 public class LciController {
+    // Error messages
+    private static final String LATITUDE_OUT_OF_RANGE_ERROR = "Latitude must be between -90 and 90 degrees.";
+    private static final String LONGITUDE_OUT_OF_RANGE_ERROR = "Longitude must be between -180 and 180 degrees.";
+    private static final String ALTITUDE_OUT_OF_RANGE_ERROR = "Altitude must be between -2097152 and 2097152.";
+    private static final String LATITUDE_NOT_NUMBER_ERROR = "Latitude must be a decimal number.";
+    private static final String LATITUDE_UNCERTAINTY_NOT_NUMBER_ERROR = "Latitude uncertainty must be a decimal number.";
+    private static final String LONGITUDE_NOT_NUMBER_ERROR = "Longitude must be a decimal number.";
+    private static final String LONGITUDE_UNCERTAINTY_NOT_NUMBER_ERROR = "Longitude uncertainty must be a decimal number.";
+    private static final String ALTITUDE_NOT_NUMBER_ERROR = "Altitude must be a decimal number.";
+    private static final String ALTITUDE_UNCERTAINTY_NOT_NUMBER_ERROR = "Altitude uncertainty must be a decimal number.";
+
     private final LciView view;
     private final LciModel model;
 
@@ -30,18 +41,66 @@ public class LciController {
         this.view = view;
         this.model.setCallback(this);
 
-        view.addLatitudeListener(actionEvent ->
-            model.getState().setLatitude(view.getLatitude()));
-        view.addLatitudeUncertaintyListener(actionEvent ->
-            model.getState().setLatitudeUncertainty(view.getLatitudeUncertainty()));
-        view.addLongitudeListener(actionEvent ->
-            model.getState().setLongitude(view.getLongitude()));
-        view.addLongitudeUncertaintyListener(actionEvent ->
-            model.getState().setLongitudeUncertainty(view.getLongitudeUncertainty()));
-        view.addAltitudeListener(actionEvent ->
-            model.getState().setAltitude(view.getAltitude()));
-        view.addAltitudeUncertaintyListener(actionEvent ->
-            model.getState().setAltitudeUncertainty(view.getAltitudeUncertainty()));
+        view.addLatitudeListener(actionEvent -> {
+            try {
+                double latitude = view.getLatitude();
+                try {
+                    model.getState().setLatitude(latitude);
+                } catch (NumberFormatException exception) {
+                    view.displayError(LATITUDE_OUT_OF_RANGE_ERROR);
+                }
+            } catch (NumberFormatException exception) {
+                view.displayError(LATITUDE_NOT_NUMBER_ERROR);
+            }
+        });
+        view.addLatitudeUncertaintyListener(actionEvent -> {
+            try {
+                double latitudeUncertainty = view.getLatitudeUncertainty();
+                model.getState().setLatitudeUncertainty(latitudeUncertainty);
+            } catch (NumberFormatException exception) {
+                view.displayError(LATITUDE_UNCERTAINTY_NOT_NUMBER_ERROR);
+            }
+        });
+        view.addLongitudeListener(actionEvent -> {
+            try {
+                double longitude = view.getLongitude();
+                try {
+                    model.getState().setLongitude(longitude);
+                } catch (NumberFormatException exception) {
+                    view.displayError(LONGITUDE_OUT_OF_RANGE_ERROR);
+                }
+            } catch (NumberFormatException exception) {
+                view.displayError(LONGITUDE_NOT_NUMBER_ERROR);
+            }
+        });
+        view.addLongitudeUncertaintyListener(actionEvent -> {
+            try {
+                double longitudeUncertainty = view.getLongitudeUncertainty();
+                model.getState().setLongitudeUncertainty(longitudeUncertainty);
+            } catch (NumberFormatException exception) {
+                view.displayError(LONGITUDE_UNCERTAINTY_NOT_NUMBER_ERROR);
+            }
+        });
+        view.addAltitudeListener(actionEvent -> {
+            try {
+                double altitude = view.getAltitude();
+                try {
+                    model.getState().setAltitude(altitude);
+                } catch (NumberFormatException exception) {
+                    view.displayError(ALTITUDE_OUT_OF_RANGE_ERROR);
+                }
+            } catch (NumberFormatException exception) {
+                view.displayError(ALTITUDE_NOT_NUMBER_ERROR);
+            }
+        });
+        view.addAltitudeUncertaintyListener(actionEvent -> {
+            try {
+                double altitudeUncertainty = view.getAltitudeUncertainty();
+                model.getState().setAltitudeUncertainty(altitudeUncertainty);
+            } catch (NumberFormatException exception) {
+                view.displayError(ALTITUDE_UNCERTAINTY_NOT_NUMBER_ERROR);
+            }
+        });
         view.addAltitudeTypeListener(actionEvent ->
             model.getState().setAltitudeType(view.getAltitudeType()));
         view.addMapDatumListener(actionEvent ->

--- a/WifiART/src/userinterface/LciModel.java
+++ b/WifiART/src/userinterface/LciModel.java
@@ -16,10 +16,72 @@ limitations under the License.
 
 package userinterface;
 
+import structs.AltitudeType;
 import structs.LciState;
+import structs.MapDatum;
 import structs.Subelement;
 
 public class LciModel implements Subelement {
+
+    // Constants
+    private static final byte SUBELEMENT_ID = 0;
+    private static final int MAX_LATITUDE_UNCERTAINTY_ENCODING = 34;
+    private static final int MIN_LATITUDE_UNCERTAINTY_ENCODING = 1;
+    private static final int MAX_LONGITUDE_UNCERTAINTY_ENCODING = 34;
+    private static final int MIN_LONGITUDE_UNCERTAINTY_ENCODING = 1;
+    private static final int MAX_ALTITUDE_UNCERTAINTY_ENCODING = 30;
+    private static final int MIN_ALTITUDE_UNCERTAINTY_ENCODING = 1;
+
+    // Indices of field groups (in bytes)
+    private static final int SUBELEMENT_ID_INDEX = 0;
+    private static final int LENGTH_INDEX = 1;
+    private static final int LATITUDE_FIELDS_INDEX = 2;
+    private static final int LONGITUDE_FIELDS_INDEX = 7;
+    private static final int ALTITUDE_FIELDS_INDEX = 12;
+    private static final int MISCELLANEOUS_FIELDS_INDEX = 17;
+
+    // Lengths of field groups (in bytes)
+    private static final int SUBELEMENT_ID_LENGTH = 1;
+    private static final int LENGTH_FIELD_LENGTH = 1;
+    private static final int LATITUDE_FIELDS_LENGTH = 5;
+    private static final int LONGITUDE_FIELDS_LENGTH = 5;
+    private static final int ALTITUDE_FIELDS_LENGTH = 5;
+    private static final int MISCELLANEOUS_FIELDS_LENGTH = 1;
+
+    // Indices of fields within groups (in bits)
+    private static final int LATITUDE_UNCERTAINTY_INDEX = 0;
+    private static final int LATITUDE_INDEX = 6;
+
+    private static final int LONGITUDE_UNCERTAINTY_INDEX = 0;
+    private static final int LONGITUDE_INDEX = 6;
+
+    private static final int ALTITUDE_UNITS_INDEX = 0;
+    private static final int ALTITUDE_UNCERTAINTY_INDEX = 4;
+    private static final int ALTITUDE_INDEX = 10;
+
+    private static final int MAP_DATUM_INDEX = 0;
+    private static final int REG_LOC_AGREEMENT_INDEX = 3;
+    private static final int REG_LOC_DSE_INDEX = 4;
+    private static final int DEPENDENT_STA_INDEX = 5;
+    private static final int VERSION_INDEX = 6;
+
+    // Lengths of fields within groups (in bits)
+    private static final int LATITUDE_UNCERTAINTY_LENGTH = 6;
+    private static final int LATITUDE_LENGTH = 34;
+
+    private static final int LONGITUDE_UNCERTAINTY_LENGTH = 6;
+    private static final int LONGITUDE_LENGTH = 34;
+
+    private static final int ALTITUDE_UNITS_LENGTH = 4;
+    private static final int ALTITUDE_UNCERTAINTY_LENGTH = 6;
+    private static final int ALTITUDE_LENGTH = 30;
+
+    private static final int MAP_DATUM_LENGTH = 3;
+    private static final int REG_LOC_AGREEMENT_LENGTH = 1;
+    private static final int REG_LOC_DSE_LENGTH = 1;
+    private static final int DEPENDENT_STA_LENGTH = 1;
+    private static final int VERSION_LENGTH = 2;
+
 
     private LciState state;
     private LciController fc;
@@ -61,10 +123,147 @@ public class LciModel implements Subelement {
     }
 
 
-
-    // TODO(dmevans) Implement the encoding in toHexBuffer().
     @Override
     public String toHexBuffer() {
-        return null;
+        byte fieldsLength = LATITUDE_FIELDS_LENGTH + LONGITUDE_FIELDS_LENGTH
+            + ALTITUDE_FIELDS_LENGTH + MISCELLANEOUS_FIELDS_LENGTH;
+        byte[] buffer = new byte[SUBELEMENT_ID_LENGTH + LENGTH_FIELD_LENGTH + fieldsLength];
+
+        buffer[SUBELEMENT_ID_INDEX] = SUBELEMENT_ID;
+        buffer[LENGTH_INDEX] = fieldsLength;
+
+        long latitudeFields = getLatitudeFields();
+        fillLittleEndian(buffer, latitudeFields, LATITUDE_FIELDS_INDEX, LATITUDE_FIELDS_LENGTH);
+        long longitudeFields = getLongitudeFields();
+        fillLittleEndian(buffer, longitudeFields, LONGITUDE_FIELDS_INDEX, LONGITUDE_FIELDS_LENGTH);
+        long altitudeFields = getAltitudeFields();
+        fillLittleEndian(buffer, altitudeFields, ALTITUDE_FIELDS_INDEX, ALTITUDE_FIELDS_LENGTH);
+        int miscellaneousFields = getMiscellaneousFields();
+        fillLittleEndian(buffer, miscellaneousFields, MISCELLANEOUS_FIELDS_INDEX, MISCELLANEOUS_FIELDS_LENGTH);
+
+        String result = "";
+        for (byte b : buffer) {
+            result += String.format("%02x", b); // Convert the byte to a hex string of 2 characters.
+        }
+        return result;
     }
+
+    private long getLatitudeFields() {
+        double latitudeUncertainty = state.getLatitudeUncertainty();
+        // LatUnc = 8 - log_2(uncertainty) -> rounded down
+        int latitudeUncertaintyEncoding = 0;
+        if (latitudeUncertainty > 0) { // User has provided an longitude uncertainty
+            latitudeUncertaintyEncoding = (int) (8 - Math.log(latitudeUncertainty) / Math.log(2));
+            if (latitudeUncertaintyEncoding > MAX_LATITUDE_UNCERTAINTY_ENCODING) {
+                latitudeUncertaintyEncoding = MAX_LATITUDE_UNCERTAINTY_ENCODING;
+            } else if (latitudeUncertaintyEncoding < MIN_LATITUDE_UNCERTAINTY_ENCODING) {
+                latitudeUncertaintyEncoding = MIN_LATITUDE_UNCERTAINTY_ENCODING;
+            }
+        }
+
+        double latitude = state.getLatitude();
+        long latitudeEncoding = Math.round(latitude * 0x0000000002000000L);
+        if (latitude < 0) {
+            latitudeEncoding = 0x0000000400000000L - latitudeEncoding;
+        }
+
+        long result = 0;
+        result |= ((latitudeUncertaintyEncoding << LATITUDE_UNCERTAINTY_INDEX) & 0x000000000000003fL);
+        result |= ((latitudeEncoding << LATITUDE_INDEX) & 0x000000ffffffffc0L);
+        return result;
+    }
+
+    private long getLongitudeFields() {
+        double longitudeUncertainty = state.getLongitudeUncertainty();
+        // LongUnc = 8 - log_2(uncertainty) -> rounded down
+        int longitudeUncertaintyEncoding = 0;
+        if (longitudeUncertainty > 0) { // User has provided an longitude uncertainty
+            longitudeUncertaintyEncoding = (int) (8 - Math.log(longitudeUncertainty) / Math.log(2));
+            if (longitudeUncertaintyEncoding > MAX_LONGITUDE_UNCERTAINTY_ENCODING) {
+                longitudeUncertaintyEncoding = MAX_LONGITUDE_UNCERTAINTY_ENCODING;
+            } else if (longitudeUncertaintyEncoding < MIN_LONGITUDE_UNCERTAINTY_ENCODING) {
+                longitudeUncertaintyEncoding = MIN_LONGITUDE_UNCERTAINTY_ENCODING;
+            }
+        }
+
+        double longitude = state.getLongitude();
+        long longitudeEncoding = Math.round(longitude * 0x0000000002000000L);
+        if (longitude < 0) {
+            longitudeEncoding = 0x0000000400000000L - longitudeEncoding;
+        }
+
+        long result = 0;
+        result |= ((longitudeUncertaintyEncoding << LONGITUDE_UNCERTAINTY_INDEX) & 0x000000000000003fL);
+        result |= ((longitudeEncoding << LONGITUDE_INDEX) & 0x000000ffffffffc0L);
+        return result;
+    }
+
+    private long getAltitudeFields() {
+        AltitudeType altitudeType = state.getAltitudeType();
+        int altitudeTypeEncoding = altitudeType.getEncoding();
+
+        double altitudeUncertainty = state.getAltitudeUncertainty();
+        // AltUnc = 21 - log_2(uncertainty) -> rounded down
+        int altitudeUncertaintyEncoding = 0;
+        if (altitudeUncertainty > 0) { // User has provided an altitude uncertainty
+            altitudeUncertaintyEncoding = (int) (21 - Math.log(altitudeUncertainty) / Math.log(2));
+            if (altitudeUncertaintyEncoding > MAX_ALTITUDE_UNCERTAINTY_ENCODING) {
+                altitudeUncertaintyEncoding = MAX_ALTITUDE_UNCERTAINTY_ENCODING;
+            } else if (altitudeUncertaintyEncoding < MIN_ALTITUDE_UNCERTAINTY_ENCODING) {
+                altitudeUncertaintyEncoding = MIN_ALTITUDE_UNCERTAINTY_ENCODING;
+            }
+        }
+
+        double altitude = state.getAltitude();
+        long altitudeEncoding = Math.round(altitude * 0x0000000000000100L);
+        if (altitude < 0) {
+            altitudeEncoding = 0x0000000040000000L - altitudeEncoding;
+        }
+
+        long result = 0;
+        result |= ((altitudeTypeEncoding << ALTITUDE_UNITS_INDEX) & 0x000000000000000fL);
+        result |= ((altitudeUncertaintyEncoding << ALTITUDE_UNCERTAINTY_INDEX) & 0x00000000000003f0L);
+        result |= ((altitudeEncoding << ALTITUDE_INDEX) & 0x000000fffffffc00L);
+        return result;
+    }
+
+    private int getMiscellaneousFields() {
+        MapDatum mapDatum = state.getMapDatum();
+        int mapDatumEncoding = mapDatum.getEncoding();
+
+        boolean regLocAgreement = state.getRegLocAgreement();
+        int regLocAgreementEncoding = regLocAgreement ? 1 : 0;
+
+        boolean regLocDse = state.getRegLocDse();
+        int regLocDseEncoding = regLocDse ? 1 : 0;
+
+        boolean dependentSta = state.getDependentSta();
+        int dependentStaEncoding = dependentSta ? 1 : 0;
+
+        int version = state.getLciVersion();
+
+        int result = 0;
+        result |= ((mapDatumEncoding << MAP_DATUM_INDEX) & 0x00000007);
+        result |= ((regLocAgreementEncoding << REG_LOC_AGREEMENT_INDEX) & 0x00000008);
+        result |= ((regLocDseEncoding << REG_LOC_DSE_INDEX) & 0x00000010);
+        result |= ((dependentStaEncoding << DEPENDENT_STA_INDEX) & 0x00000020);
+        result |= ((version << VERSION_INDEX) & 0x000000c0);
+        return result;
+    }
+
+    /**
+     * Insert an integer into a byte array in little-endian format.
+     *
+     * @param arr The byte array being populated
+     * @param num The integer to insert into the array
+     * @param startIndex The starting index that the integer should appear in the array
+     * @param length The number of bytes being populated
+     */
+    private void fillLittleEndian(byte[] arr, long num, int startIndex, int length) {
+        for (int i = 0; i < length; i++) {
+            arr[startIndex + i] = (byte)(num & 0xff); // Insert the least-significant byte into the array.
+            num >>= 8; // Move the next byte into the least-significant position.
+        }
+    }
+
 }

--- a/WifiART/src/userinterface/LciView.java
+++ b/WifiART/src/userinterface/LciView.java
@@ -3,14 +3,7 @@ package userinterface;
 import structs.AltitudeType;
 import structs.MapDatum;
 
-import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JTextField;
+import javax.swing.*;
 import java.awt.Color;
 import java.awt.FlowLayout;
 import java.awt.event.ActionListener;
@@ -145,6 +138,7 @@ public class LciView extends JPanel {
      * @return the LCI version.
      */
     public int getLciVersion() {
+        // parseInt will work here because the JComboBox is populated with an integer array.
         return Integer.parseInt(String.valueOf(lciVersionComboBox.getSelectedItem()));
     }
 
@@ -382,5 +376,13 @@ public class LciView extends JPanel {
         lciVersionComboBox.addActionListener(listener);
     }
 
+    /**
+     * Displays an error in a pop-up window.
+     *
+     * @param message The error message to be displayed.
+     */
+    public void displayError(String message) {
+        JOptionPane.showMessageDialog(new JFrame(), message);
+    }
 
 }

--- a/WifiART/src/userinterface/LciView.java
+++ b/WifiART/src/userinterface/LciView.java
@@ -3,7 +3,16 @@ package userinterface;
 import structs.AltitudeType;
 import structs.MapDatum;
 
-import javax.swing.*;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
 import java.awt.Color;
 import java.awt.FlowLayout;
 import java.awt.event.ActionListener;
@@ -109,7 +118,6 @@ public class LciView extends JPanel {
         JPanel lciReservedFieldsPanel = new JPanel();
         setupLciReservedFieldsPanel(lciReservedFieldsPanel);
         this.add(lciReservedFieldsPanel);
-
     }
 
     private void setupLciReservedFieldsPanel(JPanel lciReservedFieldsPanel) {

--- a/WifiART/src/userinterface/LciView.java
+++ b/WifiART/src/userinterface/LciView.java
@@ -1,5 +1,8 @@
 package userinterface;
 
+import structs.AltitudeType;
+import structs.MapDatum;
+
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -10,6 +13,7 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 import java.awt.Color;
 import java.awt.FlowLayout;
+import java.awt.event.ActionListener;
 
 /**
  * A JPanel representing the view for the LCI subelement.
@@ -18,8 +22,16 @@ public class LciView extends JPanel {
 
     // Constants
     private static final Integer[] LCI_VERSION_LIST = {1};
-    private static final String[] ALTITUDE_TYPE_LIST = {"No Altitude Provided", "Meters", "Floors"};
-    private static final String[] MAP_DATUM_LIST = {"WGS84", "NAD83 (NAVD88)", "NAD83 (MLLW)"};
+    private static final String NO_KNOWN_ALTITUDE_LABEL = "No Altitude Provided";
+    private static final String ALTITUDE_IN_METERS_LABEL = "Meters";
+    private static final String ALTITUDE_IN_FLOORS_LABEL = "Floors";
+    private static final String[] ALTITUDE_TYPE_LIST = {NO_KNOWN_ALTITUDE_LABEL,
+        ALTITUDE_IN_METERS_LABEL, ALTITUDE_IN_FLOORS_LABEL};
+    private static final String WGS84_DATUM_LABEL = "WGS84";
+    private static final String NAD83_NAVD88_DATUM_LABEL = "NAD83 (NAVD88)";
+    private static final String NAD83_MLLW_DATUM_LABEL = "NAD83 (MLLW)";
+    private static final String[] MAP_DATUM_LIST = {WGS84_DATUM_LABEL,
+        NAD83_NAVD88_DATUM_LABEL, NAD83_MLLW_DATUM_LABEL};
 
     // Labels for titled borders
     private static final String LCI_RESERVED_FIELDS_LABEL = "IEEE 802.11y features";
@@ -42,7 +54,7 @@ public class LciView extends JPanel {
     private final JTextField altitudeUncertaintyField = new JTextField();
     private final JLabel altitudeTypeComboBoxLabel = new JLabel(" Altitude Units: ");
     private final JComboBox<String> altitudeTypeComboBox = new JComboBox<>(ALTITUDE_TYPE_LIST);
-    private final JLabel mapDatumComboBoxLabel = new JLabel(" Altitude Datum: ");
+    private final JLabel mapDatumComboBoxLabel = new JLabel(" Map Datum: ");
     private final JComboBox<String> mapDatumComboBox = new JComboBox<>(MAP_DATUM_LIST);
     private final JCheckBox regLocAgreementCheckbox = new JCheckBox("<html>The STA is operating within a national policy area "
         + "<br> or an international agreement area near a national border.</html>");
@@ -123,5 +135,252 @@ public class LciView extends JPanel {
         dependentStaCheckboxPanel.add(dependentStaCheckbox);
         lciReservedFieldsPanel.add(dependentStaCheckboxPanel);
     }
+
+
+    // Getter methods for the parameters
+
+    /**
+     * Gets the LCI version.
+     *
+     * @return the LCI version.
+     */
+    public int getLciVersion() {
+        return Integer.parseInt(String.valueOf(lciVersionComboBox.getSelectedItem()));
+    }
+
+    /**
+     * Gets the latitude.
+     *
+     * @return the latitude, in degrees
+     * @throws NumberFormatException if the user did not enter a decimal number
+     */
+    public double getLatitude() throws NumberFormatException {
+        return Double.parseDouble(latitudeField.getText());
+    }
+
+    /**
+     * Gets the latitude uncertainty.
+     *
+     * @return the latitude uncertainty, in degrees
+     * @throws NumberFormatException if the user did not enter a decimal number
+     */
+    public double getLatitudeUncertainty() throws NumberFormatException {
+        return Double.parseDouble(latitudeUncertaintyField.getText());
+    }
+
+    /**
+     * Gets the longitude.
+     *
+     * @return the longitude, in degrees
+     * @throws NumberFormatException if the user did not enter a decimal number
+     */
+    public double getLongitude() throws NumberFormatException {
+        return Double.parseDouble(longitudeField.getText());
+    }
+
+    /**
+     * Gets the longitude uncertainty.
+     *
+     * @return the longitude uncertainty, in degrees
+     * @throws NumberFormatException if the user did not enter a decimal number
+     */
+    public double getLongitudeUncertainty() throws NumberFormatException {
+        return Double.parseDouble(longitudeUncertaintyField.getText());
+    }
+
+    /**
+     * Gets the altitude.
+     *
+     * @return the altitude
+     * @throws NumberFormatException if the user did not enter a decimal number
+     */
+    public double getAltitude() throws NumberFormatException {
+        return Double.parseDouble(altitudeField.getText());
+    }
+
+    /**
+     * Gets the altitude uncertainty.
+     *
+     * @return the altitude uncertainty
+     * @throws NumberFormatException if the user did not enter a decimal number
+     */
+    public double getAltitudeUncertainty() throws NumberFormatException {
+        return Double.parseDouble(altitudeUncertaintyField.getText());
+    }
+
+    /**
+     * Gets the altitude type.
+     *
+     * @return the altitude type (Meters, Floors, or No Known Altitude)
+     */
+    public AltitudeType getAltitudeType() {
+        String altitudeTypeLabel = String.valueOf(altitudeTypeComboBox.getSelectedItem());
+        if (altitudeTypeLabel.equals(NO_KNOWN_ALTITUDE_LABEL)) {
+            return AltitudeType.NO_KNOWN_ALTITUDE;
+        } else if (altitudeTypeLabel.equals(ALTITUDE_IN_METERS_LABEL)) {
+            return AltitudeType.ALTITUDE_IN_METERS;
+        } else if (altitudeTypeLabel.equals(ALTITUDE_IN_FLOORS_LABEL)) {
+            return AltitudeType.ALTITUDE_IN_FLOORS;
+        } else {
+            return null; // JComboBox must have one of the three values selected.
+        }
+    }
+
+    /**
+     * Gets the map datum.
+     *
+     * @return the map datum
+     */
+    public MapDatum getMapDatum() {
+        String datumLabel = String.valueOf(mapDatumComboBox.getSelectedItem());
+        if (datumLabel.equals(WGS84_DATUM_LABEL)) {
+            return MapDatum.WGS84;
+        } else if (datumLabel.equals(NAD83_NAVD88_DATUM_LABEL)) {
+            return MapDatum.NAD83_NAVD88;
+        } else if (datumLabel.equals(NAD83_MLLW_DATUM_LABEL)) {
+            return MapDatum.NAD83_MLLW;
+        } else {
+            return null; // JComboBox must have one of the three values selected.
+        }
+    }
+
+    /**
+     * Gets the RegLoc Agreement parameter.
+     *
+     * @return the boolean value of the parameter.
+     */
+    public boolean getRegLocAgreement() {
+        return regLocAgreementCheckbox.isSelected();
+    }
+
+    /**
+     * Gets the RegLoc DSE parameter.
+     *
+     * @return the boolean value of the parameter.
+     */
+    public boolean getRegLocDse() {
+        return regLocDseCheckbox.isSelected();
+    }
+
+    /**
+     * Gets the Dependent STA parameter.
+     *
+     * @return the boolean value of the parameter.
+     */
+    public boolean getDependentSta() {
+        return dependentStaCheckbox.isSelected();
+    }
+
+
+    // Methods for adding listeners
+
+    /**
+     * Adds a listener for the Latitude parameter.
+     *
+     * @param listener the ActionListener for the parameter.
+     */
+    public void addLatitudeListener(ActionListener listener) {
+        latitudeField.addActionListener(listener);
+    }
+
+    /**
+     * Adds a listener for the Latitude Uncertainty parameter.
+     *
+     * @param listener the ActionListener for the parameter.
+     */
+    public void addLatitudeUncertaintyListener(ActionListener listener) {
+        latitudeUncertaintyField.addActionListener(listener);
+    }
+
+    /**
+     * Adds a listener for the Longitude parameter.
+     *
+     * @param listener the ActionListener for the parameter.
+     */
+    public void addLongitudeListener(ActionListener listener) {
+        longitudeField.addActionListener(listener);
+    }
+
+    /**
+     * Adds a listener for the Longitude Uncertainty parameter.
+     *
+     * @param listener the ActionListener for the parameter.
+     */
+    public void addLongitudeUncertaintyListener(ActionListener listener) {
+        longitudeUncertaintyField.addActionListener(listener);
+    }
+
+    /**
+     * Adds a listener for the Altitude parameter.
+     *
+     * @param listener the ActionListener for the parameter.
+     */
+    public void addAltitudeListener(ActionListener listener) {
+        altitudeField.addActionListener(listener);
+    }
+
+    /**
+     * Adds a listener for the Altitude Uncertainty parameter.
+     *
+     * @param listener the ActionListener for the parameter.
+     */
+    public void addAltitudeUncertaintyListener(ActionListener listener) {
+        altitudeUncertaintyField.addActionListener(listener);
+    }
+
+    /**
+     * Adds a listener for the Altitude Type parameter.
+     *
+     * @param listener the ActionListener for the parameter.
+     */
+    public void addAltitudeTypeListener(ActionListener listener) {
+        altitudeTypeComboBox.addActionListener(listener);
+    }
+
+    /**
+     * Adds a listener for the Map Datum parameter.
+     *
+     * @param listener the ActionListener for the parameter.
+     */
+    public void addMapDatumListener(ActionListener listener) {
+        mapDatumComboBox.addActionListener(listener);
+    }
+
+    /**
+     * Adds a listener for the RegLoc Agreement parameter.
+     *
+     * @param listener the ActionListener for the parameter.
+     */
+    public void addRegLocAgreementListener(ActionListener listener) {
+        regLocAgreementCheckbox.addActionListener(listener);
+    }
+
+    /**
+     * Adds a listener for the RegLoc DSE parameter.
+     *
+     * @param listener the ActionListener for the parameter.
+     */
+    public void addRegLocDseListener(ActionListener listener) {
+        regLocDseCheckbox.addActionListener(listener);
+    }
+
+    /**
+     * Adds a listener for the Dependent STA parameter.
+     *
+     * @param listener the ActionListener for the parameter.
+     */
+    public void addDependentStaListener(ActionListener listener) {
+        dependentStaCheckbox.addActionListener(listener);
+    }
+
+    /**
+     * Adds a listener for the LCI Version parameter.
+     *
+     * @param listener the ActionListener for the parameter.
+     */
+    public void addLciVersionListener(ActionListener listener) {
+        lciVersionComboBox.addActionListener(listener);
+    }
+
 
 }

--- a/WifiART/src/userinterface/LciView.java
+++ b/WifiART/src/userinterface/LciView.java
@@ -239,7 +239,7 @@ public class LciView extends JPanel {
     }
 
     /**
-     * Gets the RegLoc Agreement parameter.
+     * Gets the Registered Location (RegLoc) Agreement parameter.
      *
      * @return the boolean value of the parameter.
      */
@@ -248,7 +248,7 @@ public class LciView extends JPanel {
     }
 
     /**
-     * Gets the RegLoc DSE parameter.
+     * Gets the Registered Location Dependent STA Enablement (RegLoc DSE) parameter.
      *
      * @return the boolean value of the parameter.
      */
@@ -341,7 +341,7 @@ public class LciView extends JPanel {
     }
 
     /**
-     * Adds a listener for the RegLoc Agreement parameter.
+     * Adds a listener for the Registered Location (RegLoc) Agreement parameter.
      *
      * @param listener the ActionListener for the parameter.
      */
@@ -350,7 +350,7 @@ public class LciView extends JPanel {
     }
 
     /**
-     * Adds a listener for the RegLoc DSE parameter.
+     * Adds a listener for the Registered Location Dependent STA Enablement (RegLoc DSE) parameter.
      *
      * @param listener the ActionListener for the parameter.
      */


### PR DESCRIPTION
LCI subelement encoding and testing complete. MapDatum and AltitudeType are now enums. Note that the Sydney Opera House example is one of the many test states.