### PR TITLE
Updated formatting for the buffer display

### DIFF
--- a/WifiART/src/userinterface/ArtMvcController.java
+++ b/WifiART/src/userinterface/ArtMvcController.java
@@ -126,9 +126,9 @@ public class ArtMvcController {
         try {
             HashMap<SubelementName, String> lciSubelementBuffersList = model.getLciSubelementBuffersList();
             HashMap<SubelementName, String> lcrSubelementBuffersList = model.getLcrSubelementBuffersList();
-            String readableBuffer = getReadableBufferDisplay(lciSubelementBuffersList, lcrSubelementBuffersList);
             String notReadableBuffer = getNotReadableBufferDisplay(lciSubelementBuffersList, lcrSubelementBuffersList);
             if (model.getState().isReadable()) {
+                String readableBuffer = getReadableBufferDisplay(lciSubelementBuffersList, lcrSubelementBuffersList);
                 view.displayBuffer(readableBuffer);
             } else {
                 view.displayBuffer(notReadableBuffer);

--- a/WifiART/src/userinterface/ArtMvcModel.java
+++ b/WifiART/src/userinterface/ArtMvcModel.java
@@ -17,9 +17,9 @@ limitations under the License.
 package userinterface;
 
 import structs.ArtSystemState;
+import structs.SubelementName;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
 
 public class ArtMvcModel {
     private ArtSystemState state;
@@ -79,7 +79,6 @@ public class ArtMvcModel {
         lcrModel.setState(state.getLcrState());
         mapModel.setState(state.getMapState());
     }
-
 
     // Getters for the sub-models
 
@@ -194,23 +193,23 @@ public class ArtMvcModel {
     /**
      * Gets a list of the buffers for included LCI subelements.
      */
-    public List<String> getLciSubelementBuffersList() {
-        List<String> buffer = new ArrayList<>();
+    public HashMap<SubelementName, String> getLciSubelementBuffersList() {
+        HashMap<SubelementName, String> buffer = new HashMap<>();
         if (state.isLciIncluded()) {
             updateLciSubelementBuffer();
-            buffer.add(lciSubelementBuffer);
+            buffer.put(SubelementName.LCI, lciSubelementBuffer);
         }
         if (state.isZIncluded()) {
             updateZSubelementBuffer();
-            buffer.add(zSubelementBuffer);
+            buffer.put(SubelementName.Z, zSubelementBuffer);
         }
         if (state.isUsageIncluded()) {
             updateUsageSubelementBuffer();
-            buffer.add(usageSubelementBuffer);
+            buffer.put(SubelementName.USAGE, usageSubelementBuffer);
         }
         if (state.isBssidIncluded()) {
             updateBssidSubelementBuffer();
-            buffer.add(bssidSubelementBuffer);
+            buffer.put(SubelementName.BSSID, bssidSubelementBuffer);
         }
         return buffer;
     }
@@ -218,19 +217,18 @@ public class ArtMvcModel {
     /**
      * Gets a list of the buffers for included LCR subelements.
      */
-    public List<String> getLcrSubelementBuffersList() {
-        List<String> buffer = new ArrayList<>();
+    public HashMap<SubelementName, String> getLcrSubelementBuffersList() {
+        HashMap<SubelementName, String> buffer = new HashMap<>();
         if (state.isLcrIncluded()) {
             updateLcrSubelementBuffer();
-            buffer.add(lcrSubelementBuffer);
+            buffer.put(SubelementName.LCR, lcrSubelementBuffer);
         }
         if (state.isMapIncluded()) {
             updateMapSubelementBuffer();
-            buffer.add(mapSubelementBuffer);
+            buffer.put(SubelementName.MAP, mapSubelementBuffer);
         }
         return buffer;
     }
-
 
     /**
      * The callback into the ArtMvcController used when an asynchronous even occurs.
@@ -241,11 +239,4 @@ public class ArtMvcModel {
         this.controller = controller;
     }
 
-
-    /** Update the view by executing the call back on the controller. */
-    private void updateView() {
-        if (controller != null) {
-            controller.modelCallback();
-        }
-    }
 }

--- a/WifiART/src/userinterface/ArtMvcView.java
+++ b/WifiART/src/userinterface/ArtMvcView.java
@@ -37,7 +37,6 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.FlowLayout;
 import java.awt.event.ActionListener;
-import java.util.List;
 
 /**
  * The master view class including GUI elements not specific to any subelement.
@@ -93,7 +92,6 @@ public class ArtMvcView extends JFrame {
 
     private final JTabbedPane tabbedPanel = new JTabbedPane();
 
-
     // Sub-View JPanels for each subelement
     private final LciView lciView = new LciView();
     private final ZView zView = new ZView();
@@ -102,11 +100,10 @@ public class ArtMvcView extends JFrame {
     private final LcrView lcrView = new LcrView();
     private final MapView mapView = new MapView();
 
-
     /** Constructor.
      *
      * @param state the system state
-     * */
+     */
     public ArtMvcView(ArtSystemState state) {
         // Top level JFrame
         this.setTitle("LCI/LCR Tools");
@@ -512,39 +509,11 @@ public class ArtMvcView extends JFrame {
     /**
      * Displays the buffer in the window.
      *
-     * @param lciSubelementBuffersList the included LCI subelement buffers
-     * @param lcrSubelementBuffersList the included LCR subelement buffers
-     * @param readable whether or not the output should be in a readable form
+     * @param buffer the String of text to be displayed in the window
      */
-    public void displayBuffer(List<String> lciSubelementBuffersList, List<String> lcrSubelementBuffersList, boolean readable) {
-        StringBuilder totalText = new StringBuilder();
-        String betweenSubelements = "";
-        String betweenBytes = "";
-        if (readable) {
-            // Readable buffer display has a line break between subelements.
-            betweenSubelements = "\n";
-            // Readable buffer display has a space between bytes.
-            betweenBytes = " ";
-        }
-
-        for (String subelementBuffer : lciSubelementBuffersList) {
-            for (int i = 0; i <= subelementBuffer.length() - 2; i += 2) {
-                totalText.append(subelementBuffer, i, i + 2).append(betweenBytes);
-            }
-            totalText.append(betweenSubelements);
-        }
-        if (!(lcrSubelementBuffersList.isEmpty())) {
-            totalText.append("\n");
-        }
-        for (String subelementBuffer : lcrSubelementBuffersList) {
-            for (int i = 0; i <= subelementBuffer.length() - 2; i += 2) {
-                totalText.append(subelementBuffer, i, i + 2).append(" ");
-            }
-            totalText.append(betweenSubelements);
-        }
-        bufferTextArea.setText(totalText.toString());
+    public void displayBuffer(String buffer) {
+        bufferTextArea.setText(buffer);
     }
-
 
     /**
      * Display an Error message.
@@ -553,26 +522,6 @@ public class ArtMvcView extends JFrame {
      */
     void displayErrorMessage(String errorMessage) {
         JOptionPane.showMessageDialog(this, errorMessage);
-    }
-
-
-    /**
-     * Get the System State from the View.
-     *
-     * @param state the current system state
-     * @return the updated system state
-     */
-    ArtSystemState getViewState(ArtSystemState state) {
-        return state;
-    }
-
-    /**
-     * Update the View from the System State.
-     *
-     * @param state the current system state
-     */
-    public void setViewState(ArtSystemState state) {
-
     }
 }
 


### PR DESCRIPTION
Updated the buffer output to match the correct formatting for both the readable and non-readable versions. Includes the addition of the three header bytes at the beginning of the LCI and LCR elements.